### PR TITLE
Replace the deprecated `set-output` command

### DIFF
--- a/autotag.cabal
+++ b/autotag.cabal
@@ -60,5 +60,4 @@ test-suite spec
     , hspec ==2.*
     , mockery
     , process
-    , silently
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -30,4 +30,3 @@ tests:
       - autotag
       - hspec == 2.*
       - mockery
-      - silently

--- a/src/Autotag.hs
+++ b/src/Autotag.hs
@@ -48,7 +48,12 @@ run create = do
   setOutput "version-with-tags" versionWithTags
 
 setOutput :: String -> String -> IO ()
-setOutput name value = putStrLn $ "::set-output name=" <> name <> "::" <> value
+setOutput name value = do
+  mOutputFile <- getEnv "GITHUB_OUTPUT"
+  case mOutputFile of
+    Nothing -> die "Couldn't read $GITHUB_OUTPUT"
+    Just outputFile ->
+      appendFile outputFile (name <> "=" <> value <> "\n")
 
 packageVersion :: Maybe FilePath -> IO Version
 packageVersion dir = do


### PR DESCRIPTION
Updates the action to write its outputs to the file at `$GITHUB_OUTPUT`, instead of using the [now deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `set-output` stdout command.